### PR TITLE
Update mongo_future_return.py

### DIFF
--- a/salt/returners/mongo_future_return.py
+++ b/salt/returners/mongo_future_return.py
@@ -126,9 +126,14 @@ def returner(ret):
         back = _remove_dots(ret['return'])
     else:
         back = ret['return']
+        
+    if isinstance(ret, dict):
+        full_ret = _remove_dots(ret)
+    else:
+        full_ret = ret
 
     log.debug(back)
-    sdata = {'minion': ret['id'], 'jid': ret['jid'], 'return': back, 'fun': ret['fun'], 'full_ret': ret}
+    sdata = {'minion': ret['id'], 'jid': ret['jid'], 'return': back, 'fun': ret['fun'], 'full_ret': full_ret}
     if 'out' in ret:
         sdata['out'] = ret['out']
     # save returns in the saltReturns collection in the json format:

--- a/salt/returners/mongo_future_return.py
+++ b/salt/returners/mongo_future_return.py
@@ -147,9 +147,7 @@ def save_load(jid, load):
     Save the load for a given job id
     '''
     conn, mdb = _get_conn(ret=None)
-    # save load in jobs collection in the json format: {'jid': <job_id>, 'load': <unformatted load data>}
-    sdata = {'jid': jid, 'load': load}
-    mdb.jobs.insert(sdata)
+    mdb.jobs.insert(load)
 
 
 def get_load(jid):

--- a/salt/returners/mongo_future_return.py
+++ b/salt/returners/mongo_future_return.py
@@ -126,7 +126,7 @@ def returner(ret):
         back = _remove_dots(ret['return'])
     else:
         back = ret['return']
-        
+
     if isinstance(ret, dict):
         full_ret = _remove_dots(ret)
     else:
@@ -137,7 +137,7 @@ def returner(ret):
     if 'out' in ret:
         sdata['out'] = ret['out']
     # save returns in the saltReturns collection in the json format:
-    # { 'minion': <minion_name>, 'jid': <job_id>, 'return': <return info with dots removed>, 
+    # { 'minion': <minion_name>, 'jid': <job_id>, 'return': <return info with dots removed>,
     #   'fun': <function>, 'full_ret': <unformatted return with dots removed>}
     mdb.saltReturns.insert(sdata)
 

--- a/salt/returners/mongo_future_return.py
+++ b/salt/returners/mongo_future_return.py
@@ -137,7 +137,8 @@ def returner(ret):
     if 'out' in ret:
         sdata['out'] = ret['out']
     # save returns in the saltReturns collection in the json format:
-    # { 'minion': <minion_name>, 'jid': <job_id>, 'return': <return info with dots removed>, 'fun': <function>, 'full_ret': <unformatted return with dots removed>}
+    # { 'minion': <minion_name>, 'jid': <job_id>, 'return': <return info with dots removed>, 
+    #   'fun': <function>, 'full_ret': <unformatted return with dots removed>}
     mdb.saltReturns.insert(sdata)
 
 

--- a/salt/returners/mongo_future_return.py
+++ b/salt/returners/mongo_future_return.py
@@ -142,7 +142,8 @@ def save_load(jid, load):
     '''
     conn, mdb = _get_conn(ret=None)
     # save load in jobs collection in the json format: {'jid': <job_id>, 'load': <unformatted load data>}
-    mdb.jobs.insert('jid': jid, 'load': load)
+    sdata = {'jid': jid, 'load': load}
+    mdb.jobs.insert(sdata)
 
 
 def get_load(jid):

--- a/salt/returners/mongo_future_return.py
+++ b/salt/returners/mongo_future_return.py
@@ -151,7 +151,7 @@ def get_load(jid):
     Return the load associated with a given job id
     '''
     conn, mdb = _get_conn(ret=None)
-    ret = mdb.jobs.find_one({'jid':jid})
+    ret = mdb.jobs.find_one({'jid': jid})
     return ret['load']
 
 

--- a/salt/returners/mongo_return.py
+++ b/salt/returners/mongo_return.py
@@ -125,7 +125,7 @@ def returner(ret):
         back = _remove_dots(ret['return'])
     else:
         back = ret['return']
-        
+
     if isinstance(ret, dict):
         full_ret = _remove_dots(ret)
     else:
@@ -136,7 +136,7 @@ def returner(ret):
     if 'out' in ret:
         sdata['out'] = ret['out']
         # save returns in the saltReturns collection in the json format:
-    # { 'minion': <minion_name>, 'jid': <job_id>, 'return': <return info with dots removed>, 
+    # { 'minion': <minion_name>, 'jid': <job_id>, 'return': <return info with dots removed>,
     #   'fun': <function>, 'full_ret': <unformatted return with dots removed>}
     mdb.saltReturns.insert(sdata)
 


### PR DESCRIPTION
updating the mongo returner to use mongo correctly and instead of creating collections for every job and every minion putting the minion returns into the collection saltReturns and all jobs into the collection jobs. this will allow users to query the collections using mongo and will use proper keys and values so you no longer have to do full collection scans to get any information out of the database.